### PR TITLE
Add `rootInstance` to `SpecPage` Interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,11 @@ export interface SpecPage {
   root?: Element;
 
   /**
+   * Similar to `root`, except returns the component instance.
+   */
+  rootInstance?: any;
+
+  /**
    * The document created for the test.
    */
   doc: Document;


### PR DESCRIPTION
## Description

The `SpecPage` interface exported by this package is missing the `rootInstance` field.

The `rootInstance` field is defined on Stencil Core's `SpecPage` type, and it is [instantiated](https://github.com/stenciljs/jest-stencil-runner/blob/1488cc3c2d6bcc0fa52cc5ab02a543b68374f01a/src/testing.ts#L211-L219) in this package's `newSpecPage` implementation.  All that's missing is to declare it on the exported interface.

Adding `rootInstance` to the interface will give better backwards compatibility with the legacy Stencil test runner, allowing smoother migration onto Jest v30+.