### PR TITLE
Fix: Allow overriding Jest configuration in createJestStencilPreset function

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -10,23 +10,12 @@ const moduleExtensionRegexp = `(${moduleExtensions.join('|')})`;
 /**
  * Create a Jest preset configuration for Stencil components.
  */
-export function createJestStencilPreset(
-  options: {
-    rootDir?: string;
-    moduleNameMapper?: Record<string, string>;
-  } = {},
-): Config.InitialOptions {
+export function createJestStencilPreset(options: Config.InitialOptions = {}): Config.InitialOptions {
   const preset: Config.InitialOptions = {
     testEnvironment: 'node',
     moduleFileExtensions: [...moduleExtensions, 'json', 'd.ts'],
-    moduleNameMapper: {
-      '^@stencil/core/testing$': 'jest-stencil-runner',
-      '^@stencil/core$': '@stencil/core',
-      ...options.moduleNameMapper,
-    },
     setupFilesAfterEnv: ['jest-stencil-runner/setup'],
     testPathIgnorePatterns: ['/.cache', '/.stencil', '/.vscode', '/dist', '/node_modules', '/www'],
-    testRegex: `${String.raw`(/__tests__/.*|\.?(test|spec))\.` + moduleExtensionRegexp}$`,
     transform: {
       '^.+\\.(ts|tsx|jsx|js|mjs|css)(\\?.*)?$': path.resolve(__dirname, 'preprocessor.js'),
     },
@@ -34,7 +23,17 @@ export function createJestStencilPreset(
     collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts', '!src/**/*.spec.{ts,tsx}', '!src/**/*.e2e.{ts,tsx}'],
     testTimeout: 30000,
     snapshotSerializers: [path.resolve(__dirname, 'snapshot.js')],
+    ...options,
+    moduleNameMapper: {
+      '^@stencil/core/testing$': 'jest-stencil-runner',
+      '^@stencil/core$': '@stencil/core',
+      ...options.moduleNameMapper,
+    },
   };
+
+  if (!options.testMatch && !options.testRegex) {
+    preset.testRegex = `${String.raw`(/__tests__/.*|\.?(test|spec))\.` + moduleExtensionRegexp}$`;
+  }
 
   return preset;
 }


### PR DESCRIPTION
Hi, firstly thanks for supporting jest-30 in stenciljs. Currently I experimenting a problem as: CreateJestStencilPreset function doesn't respect custom options, which passed as parameter. So I created a pull request regarding to problem. I also created a minimal reproduction repo and linked it in the below

Fixes: https://github.com/stenciljs/jest-stencil-runner/issues/8 

**Description:**  
This PR updates `createJestStencilPreset` to  accept and merge user-provided Jest configuration options.

Previously, the function ignored most options passed to it. Now, it spreads the provided options into the returned preset.

Additionally, logic has been added to handle `testMatch` and `testRegex`.  If the user provides either of these options, the default `testRegex` is omitted to prevent Jest configuration conflicts (since Jest does not allow both `testMatch` and `testRegex` to be defined simultaneously).

**Motivation:**  
Users were unable to customize the Jest configuration (e.g., changing `testMatch` patterns) as documented in the README. So when a user needs to use jsdom for .ts files, and stencilPreset for .tsx files, they were unable to do that unless they add /* jsdom */ to on top of each test file

You can reproduce the problem in the demo-repository: https://github.com/OzanAlpay/jest-stencil-runner-repro, by simply running `npm run install` and then `npm run test` commands. I modify the example-test files in the original repository to create failing test cases.