### PR TITLE
fix: install setupGlobal lifecycle in setup entry

### DIFF
--- a/example/esm/src/setup/setup.spec.ts
+++ b/example/esm/src/setup/setup.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from '@jest/globals';
+import { MockHTMLElement, type MockNode } from '@stencil/core/mock-doc';
+
+import { removeDomNodes } from 'jest-stencil-runner';
+
+describe('jest setup test framework', () => {
+  describe('removeDomNodes', () => {
+    it('removes all children of the parent node', () => {
+      const parentNode = new MockHTMLElement(null, 'div');
+      parentNode.append(new MockHTMLElement(null, 'p'));
+
+      expect(parentNode.childNodes.length).toEqual(1);
+
+      removeDomNodes(parentNode);
+
+      expect(parentNode.childNodes.length).toBe(0);
+    });
+
+    it('does nothing if there is no parent node', () => {
+      const parentNode: MockNode | undefined = undefined;
+
+      removeDomNodes(parentNode);
+
+      expect(parentNode).toBeUndefined();
+    });
+
+    it('does nothing if the parent node child array is empty', () => {
+      const parentNode = new MockHTMLElement(null, 'div');
+      parentNode.childNodes = [];
+
+      removeDomNodes(parentNode);
+
+      expect(parentNode.childNodes).toStrictEqual([]);
+    });
+
+    it('does nothing if the parent node child array is `null`', () => {
+      const parentNode = new MockHTMLElement(null, 'div');
+      // the intent of this test is to guard against null-ish childNodes, hence the type assertion
+      parentNode.childNodes = null as unknown as MockNode[];
+
+      removeDomNodes(parentNode);
+
+      expect(parentNode.childNodes).toBe(null);
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,6 @@ export { createJestStencilPreset } from './preset';
 export { JestStencilRunner } from './runner';
 export { JestStencilPreprocessor } from './preprocessor';
 export { StencilEnvironment } from './environment';
-export { setupJestStencil } from './setup';
+export { removeDomNodes, setupJestStencil } from './setup';
 export { newSpecPage } from './testing';
 export type { E2EPage, EventSpy, SpecPage } from './types';

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,11 +1,30 @@
 import process from 'node:process';
 
+import { BUILD } from '@stencil/core/internal/app-data';
+import {
+  modeResolutionChain,
+  resetPlatform,
+  setErrorHandler,
+  stopAutoApplyChanges,
+  // @ts-expect-error - TODO: add types for this module
+} from '@stencil/core/internal/testing';
+import { setupGlobal, teardownGlobal, type MockDocument, type MockNode, type MockWindow } from '@stencil/core/mock-doc';
 import * as customMatchers from './matcher/index.js';
+import { resetBuildConditionals } from './reset-build-conditionals';
+import type {
+  afterEach as JestAfterEach,
+  beforeEach as JestBeforeEach,
+  expect as JestExpect,
+  jest as JestJest,
+} from '@jest/globals';
 
-import type { expect as JestExpect, jest as JestJest } from '@jest/globals';
+import type * as d from '@stencil/core/internal';
 
 declare const expect: typeof JestExpect;
 declare const jest: typeof JestJest;
+declare const beforeEach: typeof JestBeforeEach;
+declare const afterEach: typeof JestAfterEach;
+declare const global: d.JestEnvironmentGlobal;
 
 /**
  * Setup function for Jest with Stencil testing.
@@ -17,6 +36,61 @@ export function setupJestStencil(): void {
 
   // Configure timeouts
   setupTimeouts();
+
+  global.resourcesUrl = '/build';
+
+  setupGlobal(global);
+
+  beforeEach(() => {
+    // reset the platform for this new test
+    resetPlatform();
+    setErrorHandler(undefined);
+    resetBuildConditionals(BUILD);
+    modeResolutionChain.length = 0;
+  });
+
+  afterEach(() => {
+    stopAutoApplyChanges();
+
+    // Remove each node from the mocked DOM
+    // Without this step, a component's `disconnectedCallback`
+    // will not be called since this only happens when a node is removed,
+    // not if the window is destroyed.
+    //
+    // So, we do this outside the mocked window/DOM teardown
+    // because this operation is really only necessary in the testing
+    // context so any "cleanup" operations in the `disconnectedCallback`
+    // can happen to prevent testing errors with async code in the component
+    //
+    // We only care about removing all the nodes that are children of the 'body' tag/node.
+    // This node is a child of the `html` tag which is the 2nd child of the document (hence
+    // the `1` index).
+    const bodyNode = (
+      ((global as any).window as MockWindow)?.document as unknown as MockDocument
+    )?.childNodes?.[1]?.childNodes?.find((ref) => ref.nodeName === 'BODY');
+    bodyNode?.childNodes?.forEach(removeDomNodes);
+
+    teardownGlobal(global);
+    global.resourcesUrl = '/build';
+  });
+}
+
+/**
+ * Recursively removes all child nodes of a passed node starting with the
+ * furthest descendant and then moving back up the DOM tree.
+ *
+ * @param node The mocked DOM node that will be removed from the DOM
+ */
+export function removeDomNodes(node: MockNode | undefined | null) {
+  if (node == null) {
+    return;
+  }
+
+  if (!node.childNodes?.length) {
+    node.remove();
+  }
+
+  node.childNodes?.forEach(removeDomNodes);
 }
 
 /**


### PR DESCRIPTION
Restores the DOM setup and per-test cleanup the integrated Stencil Jest 29 runner installed via setupGlobal/teardownGlobal

Without this, any spec that touches window/document/location etc. outside a newSpecPage call throws ReferenceError, and disconnectedCallback never fires between tests.

fixes #13