### PR TITLE
fix: map all @stencil/core subpaths in the preset

### DIFF
--- a/example/esm/src/module-resolution/module-resolution.spec.ts
+++ b/example/esm/src/module-resolution/module-resolution.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from '@jest/globals';
+import * as StencilInternal from '@stencil/core/internal';
+import { MockDocument } from '@stencil/core/mock-doc';
+
+describe('stencil subpath module resolution', () => {
+  it('@stencil/core/internal loads without SyntaxError', () => {
+    expect(StencilInternal).toBeTruthy();
+  });
+
+  it('@stencil/core/mock-doc exposes MockDocument', () => {
+    expect(MockDocument).toBeTruthy();
+  });
+});

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1,9 +1,14 @@
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import url from 'node:url';
 
 import type { Config } from '@jest/types';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const requireFromHere = createRequire(import.meta.url);
+const stencilRootDir = path.resolve(path.dirname(requireFromHere.resolve('@stencil/core/mock-doc')), '..');
+const stencilInternalDir = path.join(stencilRootDir, 'internal');
+
 const moduleExtensions = ['ts', 'tsx', 'js', 'mjs', 'jsx'];
 const moduleExtensionRegexp = `(${moduleExtensions.join('|')})`;
 
@@ -25,8 +30,16 @@ export function createJestStencilPreset(options: Config.InitialOptions = {}): Co
     ...options,
     setupFilesAfterEnv: ['jest-stencil-runner/setup', ...(options.setupFilesAfterEnv ?? [] )],
     moduleNameMapper: {
+      '^@stencil/core/cli$': path.join(stencilRootDir, 'cli', 'index.js'),
+      '^@stencil/core/compiler$': path.join(stencilRootDir, 'compiler', 'stencil.js'),
+      '^@stencil/core/internal$': path.join(stencilInternalDir, 'testing', 'index.js'),
+      '^@stencil/core/internal/app-data$': path.join(stencilInternalDir, 'app-data', 'index.cjs'),
+      '^@stencil/core/internal/app-globals$': path.join(stencilInternalDir, 'app-globals', 'index.js'),
+      '^@stencil/core/internal/testing$': path.join(stencilInternalDir, 'testing', 'index.js'),
+      '^@stencil/core/mock-doc$': path.join(stencilRootDir, 'mock-doc', 'index.cjs'),
+      '^@stencil/core/sys$': path.join(stencilRootDir, 'sys', 'node', 'index.js'),
       '^@stencil/core/testing$': 'jest-stencil-runner',
-      '^@stencil/core$': '@stencil/core',
+      '^@stencil/core$': path.join(stencilInternalDir, 'testing', 'index.js'),
       ...options.moduleNameMapper,
     },
   };


### PR DESCRIPTION
Jest 30's node env does not honor the `import` export condition of @stencil/core, so subpaths like @stencil/core/internal fail to resolve with Cannot find module SyntaxError

Adds the 10 moduleNameMapper entries from the integrated Stencil Jest 29 preset, each pointing at the pre-built CJS/JS file in @stencil/core's install. 

closes #17